### PR TITLE
chore: 📢 Bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "macadam",
   "displayName": "Macadam",
   "description": "Integration for macadam: a tool to create/start linux VM on any OS",
-  "version": "0.0.1",
+  "version": "0.2.0-next",
   "icon": "icon.png",
   "license": "Apache-2.0",
   "publisher": "redhat",


### PR DESCRIPTION
📢 Bump version to 0.2.0

0.1.1 has been released.

 Time to switch to the new 0.2.0 version 🥳
